### PR TITLE
Don't try to play the song we are already playing

### DIFF
--- a/djserver.js
+++ b/djserver.js
@@ -229,6 +229,7 @@ function announce_play(data) {
     msg.album = data.now_playing.three_line.line3;
     msg.version = pjson.version;
     msg.length = data.now_playing.length;
+    msg.seek_position = data.now_playing.seek_position;
 
     ws.send(JSON.stringify(msg));
     log.info("Announced playback of '%s - %s'", msg.title, msg.subtitle);


### PR DESCRIPTION
Check the status of our current output zone and see if we're already playing the current song.  If we are, don't do anything.  This makes it safe for the DJ to send out multiple "PLAYING" messages throughout playback without interfering with working slaves.